### PR TITLE
Memstasd func options

### DIFF
--- a/client.go
+++ b/client.go
@@ -77,11 +77,11 @@ func checkConfig(cfg *MetricsConfig) *MetricsConfig {
 	return cfg
 }
 
-func RunMemstatsd(envName string, d time.Duration, tags map[string]string) {
+func RunMemstatsd(envName string, d time.Duration, opt ...memstatsd.MemStatsdOption) {
 	if client == nil {
 		return
 	}
-	m := memstatsd.New("memstatsd.", envName, proxy{client}, tags)
+	m := memstatsd.New("memstatsd.", envName, proxy{client}, opt...)
 	m.Run(d)
 }
 

--- a/memstatsd/memstatsd.go
+++ b/memstatsd/memstatsd.go
@@ -26,6 +26,16 @@ type MemStatsd struct {
 
 type MemStatsdOption func(*MemStatsd)
 
+type Config struct {
+	Debug bool
+}
+
+func WithConfig(cfg Config) MemStatsdOption {
+	return func(m *MemStatsd) {
+		m.debug = cfg.Debug
+	}
+}
+
 func WithTags(tags map[string]string) MemStatsdOption {
 	return func(m *MemStatsd) {
 		m.ctags = tags

--- a/memstatsd/memstatsd.go
+++ b/memstatsd/memstatsd.go
@@ -24,16 +24,25 @@ type MemStatsd struct {
 	allocLatency time.Duration
 }
 
-func New(prefix string, envName string, statsd Statter, customTags map[string]string, debug ...bool) MemStatsd {
+type MemStatsdOption func(*MemStatsd)
+
+func WithTags(tags map[string]string) MemStatsdOption {
+	return func(m *MemStatsd) {
+		m.ctags = tags
+	}
+}
+
+func New(prefix string, envName string, statsd Statter, opts ...MemStatsdOption) MemStatsd {
 	m := MemStatsd{
 		prefix: prefix,
 		statsd: statsd,
 		env:    envName,
-		ctags:  customTags,
 	}
-	if len(debug) > 0 && debug[0] {
-		m.debug = true
+
+	for _, opt := range opts {
+		opt(&m)
 	}
+
 	return m
 }
 

--- a/memstatsd/memstatsd.go
+++ b/memstatsd/memstatsd.go
@@ -44,8 +44,12 @@ func WithConfig(cfg Config) MemStatsdOption {
 }
 
 func WithTags(tags Tags) MemStatsdOption {
+	t, err := structToMap(tags)
+	if err != nil {
+		panic(err)
+	}
 	return func(m *MemStatsd) {
-		m.ctags = structToMap(tags)
+		m.ctags = t
 	}
 }
 

--- a/memstatsd/memstatsd.go
+++ b/memstatsd/memstatsd.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"runtime"
+	"strings"
 	"time"
 )
 
@@ -229,7 +230,7 @@ func joinTags(tags ...map[string]string) string {
 	}
 	var str string
 	for k, v := range tags[0] {
-		str += fmt.Sprintf(",%s=%s", k, v)
+		str += fmt.Sprintf(",%s=%s", strings.ToLower(k), v)
 	}
 	return str
 }

--- a/memstatsd/memstatsd.go
+++ b/memstatsd/memstatsd.go
@@ -3,6 +3,7 @@
 package memstatsd
 
 import (
+	"encoding/json"
 	"fmt"
 	"runtime"
 	"time"
@@ -30,15 +31,19 @@ type Config struct {
 	Debug bool
 }
 
+type Tags struct {
+	Service string
+}
+
 func WithConfig(cfg Config) MemStatsdOption {
 	return func(m *MemStatsd) {
 		m.debug = cfg.Debug
 	}
 }
 
-func WithTags(tags map[string]string) MemStatsdOption {
+func WithTags(tags Tags) MemStatsdOption {
 	return func(m *MemStatsd) {
-		m.ctags = tags
+		m.ctags = structToMap(tags)
 	}
 }
 
@@ -227,4 +232,13 @@ func joinTags(tags ...map[string]string) string {
 		str += fmt.Sprintf(",%s=%s", k, v)
 	}
 	return str
+}
+
+func structToMap(s interface{}) map[string]string {
+	var m map[string]string
+
+	sm, _ := json.Marshal(s)
+	json.Unmarshal(sm, &m)
+
+	return m
 }

--- a/memstatsd/memstatsd_test.go
+++ b/memstatsd/memstatsd_test.go
@@ -15,8 +15,21 @@ func (s statter) Timing(bucket string, d time.Duration) {
 func (s statter) Gauge(bucket string, value int) {
 	log.Println(bucket, value)
 }
+
 func TestMemstatsd(t *testing.T) {
-	msd := New("memstatsd.", "testing", statter{}, map[string]string{"service": "test"}, true)
+	msd := New("memstatsd.", "testing", statter{})
+	msd.Run(5 * time.Second)
+	time.Sleep(time.Second * 10)
+
+	go func() {
+		time.Sleep(time.Minute)
+	}()
+
+	time.Sleep(time.Minute)
+}
+
+func TestMemstatsdWithTag(t *testing.T) {
+	msd := New("memstatsd.", "testing", statter{}, WithTags(map[string]string{"service": "test"}))
 	msd.Run(5 * time.Second)
 	time.Sleep(time.Second * 10)
 

--- a/memstatsd/memstatsd_test.go
+++ b/memstatsd/memstatsd_test.go
@@ -30,7 +30,7 @@ func TestMemstatsd(t *testing.T) {
 
 func TestMemstatsdWithTag(t *testing.T) {
 	msd := New("memstatsd.", "testing", statter{},
-		WithTags(map[string]string{"service": "test"}),
+		WithTags(Tags{Service: "test"}),
 		WithConfig(Config{Debug: true}))
 	msd.Run(5 * time.Second)
 	time.Sleep(time.Second * 10)

--- a/memstatsd/memstatsd_test.go
+++ b/memstatsd/memstatsd_test.go
@@ -29,7 +29,9 @@ func TestMemstatsd(t *testing.T) {
 }
 
 func TestMemstatsdWithTag(t *testing.T) {
-	msd := New("memstatsd.", "testing", statter{}, WithTags(map[string]string{"service": "test"}))
+	msd := New("memstatsd.", "testing", statter{},
+		WithTags(map[string]string{"service": "test"}),
+		WithConfig(Config{Debug: true}))
 	msd.Run(5 * time.Second)
 	time.Sleep(time.Second * 10)
 


### PR DESCRIPTION
This PR will update memstatd constructor signature to accept optional configuration functions in the form of RunMemstatsd(env, duration, WithTags(Tags{}), WithConfig(Config{})). Additionally, tags are populated via struct instead of map as per Lee's recommendation.